### PR TITLE
refactor(ui): convert interfaces to types in ColorMode components

### DIFF
--- a/components/ui/color-mode.tsx
+++ b/components/ui/color-mode.tsx
@@ -7,7 +7,7 @@ import type { ThemeProviderProps } from "next-themes"
 import * as React from "react"
 import { LuMoon, LuSun } from "react-icons/lu"
 
-export interface ColorModeProviderProps extends ThemeProviderProps {}
+export type ColorModeProviderProps = ThemeProviderProps
 
 export function ColorModeProvider(props: ColorModeProviderProps) {
   return (
@@ -46,7 +46,7 @@ export function ColorModeIcon() {
   return colorMode === "dark" ? <LuMoon /> : <LuSun />
 }
 
-interface ColorModeButtonProps extends Omit<IconButtonProps, "aria-label"> {}
+type ColorModeButtonProps = Omit<IconButtonProps, "aria-label">
 
 export const ColorModeButton = React.forwardRef<
   HTMLButtonElement,


### PR DESCRIPTION
 ## Summary
  - Convert empty interface declarations to type aliases in color-mode component
  - Resolve ESLint no-empty-object-type warnings

  ## Test plan
  - [x] Build passes without ESLint errors
  - [x] TypeScript compilation succeeds
  - [x] No runtime functionality changes